### PR TITLE
update to latest cordova-plugin-file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-network-canvas-client",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Cordova Plugin for Network Canvas API clients",
   "keywords": [
     "social",
@@ -17,7 +17,9 @@
   "license": "GPL-3.0-or-later",
   "engines": {
     "cordovaDependencies": {
-        "0.0.1": { "cordova-plugin-file": "^5.0.0"}
+      "0.0.1": {
+        "cordova-plugin-file": "^7.0.0"
+      }
     }
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-network-canvas-client" version="0.0.1">
+        id="cordova-plugin-network-canvas-client" version="0.0.2">
     <name>Network Canvas Client</name>
     <description>Cordova Plugin for Network Canvas API clients</description>
     <license>GPL-3.0-or-later</license>
     <keywords>social network,sna,visualization,research,public health,network canvas</keywords>
-    <dependency id="cordova-plugin-file" version="^5.0.0" />
+    <dependency id="cordova-plugin-file" version="^7.0.0" />
     <js-module src="www/client.js" name="client">
         <clobbers target="cordova.plugins.NetworkCanvasClient" />
     </js-module>


### PR DESCRIPTION
Newer versions of various plugins require 7.0.0 of `cordova-plugin-file`, but this plugin is causing 5.0.0 to be pulled in.