### PR TITLE
Update plugin to fix iOS protocol import from Server

### DIFF
--- a/src/ios/NetworkCanvasClient.m
+++ b/src/ios/NetworkCanvasClient.m
@@ -227,8 +227,6 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
         NSObject<CDVFileSystem> *fs = [self.cdvFilePlugin filesystemForURL:cdvUrl];
         NSString *destinationFilepath = [fs filesystemPathForURL:cdvUrl];
         
-        NSLog(@"yoo = %@ %@", destinationFile, destinationFilepath);
-        
         NSURL *destURL = [NSURL URLWithString:destinationFile];
         reqTask = [self downloadTaskForSession:session
                                    withRequest:req


### PR DESCRIPTION
The refactor to use the new file plugin broke importing protocols from Server, and nobody noticed. This PR fixed the import.

The issue was caused by expecting cdvfile:// URLs, when we now pass file:// urls. I removed cordova file specific code as much as possible, and began using the return value of the download method (a FileEntry) in Interviewer, since the file download actually generates its own temporary file name, and handles cleanup.